### PR TITLE
Update ESLint.yml - Node 18 to Node 20

### DIFF
--- a/.github/workflows/ESLint.yml
+++ b/.github/workflows/ESLint.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g eslint
       - run: eslint


### PR DESCRIPTION
Usando Node 20 para rodar ESLint em uma versão suportada.

![image](https://github.com/pagseguro/payment-magento/assets/610598/44201974-bb4c-4aee-8b54-a1ebf04025fb)
